### PR TITLE
Add "sendStateWithSpeed" option and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Then to use this in a card place the following in your entity card:
 | customLowText | String | No | 'LOW' | Sets the text of the "low" speed button |
 | customMedText | String | No | 'MED' | Sets the text of the "medium" speed button |
 | customHiText | String | No | 'HIGH' | Sets the text of the "High" speed button |
-
+| sendStateWithSpeed | Boolean | No | false | Calls the turn_on service for the fan before sending the speed, used if fan does not power on automatically when speed is set |
 
 The values for the colors can be any valid color string in "HEX", "RGB" or by color name.
 

--- a/dist/fan-percent-button-row.js
+++ b/dist/fan-percent-button-row.js
@@ -94,6 +94,7 @@ class CustomFanPercentRow extends Polymer.Element {
 		
 		this._config = {
 			customTheme: false,
+			sendStateWithSpeed: false,
 			customSetpoints: false,
 			reverseButtons: false,
 			isTwoSpeedFan: false,
@@ -121,6 +122,7 @@ class CustomFanPercentRow extends Polymer.Element {
 		const config = this._config;
 		const stateObj = hass.states[config.entity];
 		const custTheme = config.customTheme;
+		const sendStateWithSpeed = config.sendStateWithSpeed;
 		const custSetpoint = config.customSetpoints;
 		const revButtons = config.reverseButtons;
 		const twoSpdFan = config.isTwoSpeedFan;
@@ -333,15 +335,19 @@ class CustomFanPercentRow extends Polymer.Element {
 			this.hass.callService('fan', 'turn_off', param);
 			param.percentage = this._offSP;
 			this.hass.callService('fan', 'set_percentage', param);
-		} else if (level == 'low') {
-			param.percentage = this._lowSP;
-			this.hass.callService('fan', 'set_percentage', param);
-		} else if (level == 'medium') {
-			param.percentage = this._medSP;
-			this.hass.callService('fan', 'set_percentage', param);
-		} else if (level == 'high') {
-			param.percentage = this._highSP;
-			this.hass.callService('fan', 'set_percentage', param);
+		} else {
+			if (this._config.sendStateWithSpeed) {
+				this.hass.callService('fan', 'turn_on', param);
+			} if (level == 'low') {
+				param.percentage = this._lowSP;
+				this.hass.callService('fan', 'set_percentage', param);
+			} else if (level == 'medium') {
+				param.percentage = this._medSP;
+				this.hass.callService('fan', 'set_percentage', param);
+			} else if (level == 'high') {
+				param.percentage = this._highSP;
+				this.hass.callService('fan', 'set_percentage', param);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Mirrors the functionality of the original fan-control-entity-row by allowing the turn_on service to be called with each speed change, and updates documentation accordingly.

Same changes as https://github.com/finity69x2/fan-mode-button-row/pull/1 #